### PR TITLE
Update Serial Frame Format for 2.2.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ At launch, we've included HLA support for our Serial, I2C, and SPI analyzers. Al
   "start_time": 0.0052,
   "end_time": 0.0076,
   "data": {
-    "value": 42,
+    "value": b'\x42',
     "parity_error": False,
     "framing_error": False,
     "address": False, # only used in Serial MP/MDB mode.


### PR DESCRIPTION
As of 2.2.18, frame["data"]["value"] changed from an int type to a bytes object.

![image](https://user-images.githubusercontent.com/4570416/83341687-1ee24f80-a29b-11ea-909d-db0830464756.png)

If the change is intentional in 2.2.18, This PR updates the documentation for it. 
